### PR TITLE
Fixes name and version being garbled in log/settings

### DIFF
--- a/arcdps_gw2clipboard.cpp
+++ b/arcdps_gw2clipboard.cpp
@@ -291,8 +291,8 @@ arcdps_exports* mod_init() {
 		debug_log("Could not resolve gw2clipboard.exe at: " + config.gw2ClipboardExePath);
 	}
 
-	char name[] = "gw2clipboard";
-	char version[] = "1.0";
+	static char name[] = "gw2clipboard";
+	static char version[] = "1.0";
 
 	/* for arcdps */
 	memset(&arc_exports, 0, sizeof(arcdps_exports));


### PR DESCRIPTION
As per delta, it's enough to make this static. [Other addons modify the struct instead.](https://github.com/xvwyh/BuildPad/blob/c769105c7910b802763ef3ac901e964f151c8110/arcdps_buildpad/ArcdpsDefines.h#L12)